### PR TITLE
replace devtools with remotes for GH installation

### DIFF
--- a/README.rmd
+++ b/README.rmd
@@ -101,7 +101,7 @@ data <- rfema::open_fema(data_set = "fimaNfipClaims",ask_before_call = F, filter
 
 
 ## Installation
-Right now, the best way to install and use the `rfema` package is by installing directly from GitHub using `devtools::install_github("dylan-turner25/rfema")`. The FEMA API does not require an API key, meaning no further steps need be taken to start using the package
+Right now, the best way to install and use the `rfema` package is by installing directly from GitHub using `remotes::install_github("dylan-turner25/rfema")`. The FEMA API does not require an API key, meaning no further steps need be taken to start using the package
 
 
 


### PR DESCRIPTION
while these 2 calls are equivalent (`devtools` uses the `remotes` package for installation), I suggest you recommend people to use the `remotes` package for installing your package as there are no dependencies and it installs faster if your users don't have it in their package library.