### PR TITLE
fix typo, remove unecessary argument

### DIFF
--- a/R/open_fema.R
+++ b/R/open_fema.R
@@ -172,9 +172,7 @@ open_fema <- memoise::memoise(function(data_set, top_n = NULL, filters = NULL,
 
 
 
-        message(paste0(i, " out of ", itterations, " itterations completed"),
-          quote = FALSE
-        )
+        message(paste0(i, " out of ", itterations, " iterations completed"))
       }
     } else {
       result <- httr::GET(paste0(api_query))


### PR DESCRIPTION
![Screenshot from 2021-12-23 08-50-01](https://user-images.githubusercontent.com/5502922/147206851-7b820b95-c708-4251-ab9e-c33dff2d565f.png)

`quote` isn't a valid argument of `message()` so it leads to having `FALSE` displayed in the progress messages.